### PR TITLE
Removed 'app_name' string and <application> tag from manifest.

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -3,11 +3,4 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
 </manifest>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">AppVersionChecker</string>
-</resources>


### PR DESCRIPTION
The `app_name` string and the `<application>` tag in the manifest can cause conflicts with the app where the library is going to be integrated. Better if they are removed.
